### PR TITLE
Liquid model

### DIFF
--- a/carbondriver/gde_multi.py
+++ b/carbondriver/gde_multi.py
@@ -117,6 +117,7 @@ class System(torch.nn.Module):
         chemical_reaction_rates: Optional[Dict[str, float]]=None,
         co2_equilibrium: Optional[Dict[str, float]]=None,
         method: Literal['DIC', 'CO2 eql'] = 'CO2 eql',
+        system_phase: Literal['solid', 'liquid'] = 'solid',
     ):
         super().__init__()
         self.T = T
@@ -128,7 +129,11 @@ class System(torch.nn.Module):
         self.c_khco3 = c_khco3
         self.c_k = c_k
         self.dic = dic
-        self.method = method
+        self.system_phase = system_phase
+        if self.system_phase == 'liquid':
+            self.method = 'DIC'
+        else:
+            self.method = method
 
         if diffusion_coefficients is not None:
             self.diffusion_coefficients = PositiveModelData(**diffusion_coefficients)
@@ -146,7 +151,10 @@ class System(torch.nn.Module):
         if co2_equilibrium is not None:
             self.co2_equilibrium = co2_equilibrium
         else:
-            self.co2_equilibrium = self._co2_equilibrium()
+            if self.method == 'DIC':
+                self.co2_equilibrium = self.calculate_dic_solution
+            else:
+                self.co2_equilibrium = self._co2_equilibrium()
 
 
     @property
@@ -292,6 +300,11 @@ class System(torch.nn.Module):
         DCO2 = self.bruggeman(self.diffusion_coefficients['CO2'], eps)
         E_CO = self.electrode_reaction_potentials['E_0_CO']
         co2_equilibrium = self.co2_equilibrium
+        c_CO2_bulk = co2_equilibrium['CO2']
+        if self.system_phase == 'liquid':
+            co2_transfer_coeff = self.flow_channel_characteristics['K_L_CO2']
+        else:
+            co2_transfer_coeff = gdl_mass_transfer_coeff
             
         OH_neg = co2_equilibrium['OH']
         HCO3_neg = co2_equilibrium['HCO3']
@@ -307,8 +320,11 @@ class System(torch.nn.Module):
         k0_C2H4 = A/(6*F) * self.electrode_reaction_kinetics['i_0_C2H4'] * thetas['C2H4']/self.chemical_reaction_rates['c_ref'] * torch.exp(
             -overpotential_C2H4 * self.butler_volmer_factor*self.electrode_reaction_kinetics['alpha_C2H4'])
         k0 = k0_CO + k0_C2H4
-        eff_0 = 1/(M(k0)/torch.tanh(M(k0)) + k0*L/gdl_mass_transfer_coeff)
-        c00 = Hnr*self.p0*eff_0
+        eff_0 = 1/(M(k0)/torch.tanh(M(k0)) + k0*L/co2_transfer_coeff)
+        if self.system_phase == 'liquid':
+            c00 = c_CO2_bulk*eff_0
+        else:
+            c00 = Hnr*self.p0*eff_0
 
         # estimating OH- concentration
         r_H2 = A*self.electrode_reaction_kinetics['i_0_H2b'] * thetas['H2b']/F * torch.exp(-phi_ext*self.butler_volmer_factor*self.electrode_reaction_kinetics['alpha_H2b']) # phi_ext is with respect to SHE
@@ -326,8 +342,11 @@ class System(torch.nn.Module):
 
         # update CO2 concentration 
         k1 = k0 + eps*self.chemical_reaction_rates['k1f']*c10
-        eff_1 = 1/(M(k1)/torch.tanh(M(k1)) + k1*L/gdl_mass_transfer_coeff)
-        c01 = eff_1*self.p0*Hnr
+        eff_1 = 1/(M(k1)/torch.tanh(M(k1)) + k1*L/co2_transfer_coeff)
+        if self.system_phase == 'liquid':
+            c01 = eff_1*c_CO2_bulk
+        else:
+            c01 = eff_1*self.p0*Hnr
         # update OH- concentration
         r_H2_CO2 = (2*k0_CO + 6*k0_C2H4)*c01
         c11 = OH_neg + (
@@ -347,7 +366,10 @@ class System(torch.nn.Module):
             1+(B_2*C * torch.exp(-A_1*C)) / (1+torch.log(torch.sqrt(1+B_2*C*torch.exp(-A_1*C))))
             ) / C
         # salting out corrected CO2 concentration
-        c02 = eff_1*self.p0*Hnr_c(c11,c20)
+        if self.system_phase == 'liquid':
+            c02 = eff_1*c_CO2_bulk
+        else:
+            c02 = eff_1*self.p0*Hnr_c(c11,c20)
         r_H2_CO2 = (2*k0_CO + 6*k0_C2H4)*c02
         # corrected OH- concentration
         c12 = OH_neg + (
@@ -364,13 +386,16 @@ class System(torch.nn.Module):
                 k2*L**2/DCO2
             ) / torch.tanh(torch.sqrt(
                 k2*L**2/DCO2
-            )) + k2*L/gdl_mass_transfer_coeff
+            )) + k2*L/co2_transfer_coeff
         )
         A_1_1 = (
             2*self.flow_channel_characteristics['K_L_CO3']*CO3_2neg + self.flow_channel_characteristics['K_L_HCO3']*HCO3_neg + self.flow_channel_characteristics['K_L_OH']*OH_neg + L*r_H2 - self.flow_channel_characteristics['K_L_OH']*c12
         ) / (2*self.flow_channel_characteristics['K_L_CO3'])
         # formula for this B2 is different than for the previous B2
-        B_2_1 = L*2*k0*eff_2*Hnr*self.p0 / (2*self.flow_channel_characteristics['K_L_CO3']) * torch.exp(-c12*(self.salting_out_exponents['h_OH']+self.salting_out_exponents['h_K']))
+        if self.system_phase == 'liquid':
+            B_2_1 = L*2*k0*eff_2*c_CO2_bulk / (2*self.flow_channel_characteristics['K_L_CO3']) * torch.exp(-c12*(self.salting_out_exponents['h_OH']+self.salting_out_exponents['h_K']))
+        else:
+            B_2_1 = L*2*k0*eff_2*Hnr*self.p0 / (2*self.flow_channel_characteristics['K_L_CO3']) * torch.exp(-c12*(self.salting_out_exponents['h_OH']+self.salting_out_exponents['h_K']))
         c21 = A_1_1+torch.log(
             1+(
                 B_2_1*(self.salting_out_exponents['h_CO3']+2*self.salting_out_exponents['h_K']) * torch.exp(-A_1_1*(self.salting_out_exponents['h_CO3']+2*self.salting_out_exponents['h_K']))
@@ -381,7 +406,10 @@ class System(torch.nn.Module):
             self.salting_out_exponents['h_CO3']+2*self.salting_out_exponents['h_K']
         )
         c21 = torch.maximum(c21, torch.zeros_like(c21))
-        c03 = self.p0*Hnr_c(c12, c21)*eff_2
+        if self.system_phase == 'liquid':
+            c03 = c_CO2_bulk*eff_2
+        else:
+            c03 = self.p0*Hnr_c(c12, c21)*eff_2
         potential_vs_rhe = phi_ext - R*T/F*torch.log(c12/OH_neg)
         co_current_density = L*c03*k0_CO*2*F/10 # mA/cm^2
         c2h4_current_density = L*c03*k0_C2H4*6*F/10 # mA/cm^2
@@ -393,19 +421,27 @@ class System(torch.nn.Module):
         fe_c2h4 = c2h4_current_density / current_density
         parasitic = c03*c12*eps*L*self.chemical_reaction_rates['k1f']
         electrode = L*k0*c03
-        gdl_flux = gdl_mass_transfer_coeff*(
-            Hnr_c(c12,c21)*self.p0 - c03*torch.sqrt(
-                k2*L**2/DCO2
-            ) / torch.tanh(
-                torch.sqrt(k2*L**2/DCO2)
+        if self.system_phase == 'liquid':
+            gdl_flux = torch.zeros_like(c03)
+            hco3 = torch.minimum(
+                HCO3_neg+c_CO2_bulk,
+                co3*10**(3-pH)/self.initial_carbonate_equilibria['K1']
             )
-        )
-        hco3 = torch.minimum(
-            HCO3_neg+Hnr_c(c12,c21)*self.p0,
-            co3*10**(3-pH)/self.initial_carbonate_equilibria['K1']
-        )
+            solubility = torch.ones_like(c03)
+        else:
+            gdl_flux = gdl_mass_transfer_coeff*(
+                Hnr_c(c12,c21)*self.p0 - c03*torch.sqrt(
+                    k2*L**2/DCO2
+                ) / torch.tanh(
+                    torch.sqrt(k2*L**2/DCO2)
+                )
+            )
+            hco3 = torch.minimum(
+                HCO3_neg+Hnr_c(c12,c21)*self.p0,
+                co3*10**(3-pH)/self.initial_carbonate_equilibria['K1']
+            )
+            solubility = Hnr_c(c12,c21)/Hnr
         # deleted voltage and energy efficiencies for now, just to avoid possible bugs
-        solubility = Hnr_c(c12,c21)/Hnr
         return {
             'phi_ext': phi_ext,
             'k0': k0,

--- a/carbondriver/gde_multi.py
+++ b/carbondriver/gde_multi.py
@@ -325,17 +325,21 @@ class System(torch.nn.Module):
             # ============================================================
             t_H = 0.9  # H+ transference number through BPM
             co2_transfer_coeff = self.flow_channel_characteristics['K_L_CO2']
-            
-            M_val = M(k0)
-            eff_rxn = torch.tanh(M_val) / M_val
-            J_gen = t_H * r_H2 * L
-            denominator = k0 * L * eff_rxn + co2_transfer_coeff
-            c03 = J_gen / torch.clamp(denominator, min=1e-20)
+            M_val = torch.clamp(M(k0), min=1e-6)
+            Sh = co2_transfer_coeff * L / DCO2
+            k0_electron = 2*k0_CO + 6*k0_C2H4
+                # Exact effectiveness factor (average / boundary concentration)
+            eta_c = (
+                (Sh * (torch.cosh(M_val) - 1.0) / M_val**2 + torch.sinh(M_val) / M_val) /
+                (Sh * torch.cosh(M_val) + M_val * torch.sinh(M_val))
+            )
+                # Exact self-consistent solve (linear in c03, no iteration)
+            J_her = t_H * r_H2 * L
+            denominator = k0 * L + co2_transfer_coeff / eta_c - t_H * k0_electron * L
+            c03 = J_her / torch.clamp(denominator, min=1e-20)
             
             # One correction iteration for CO2R contribution to J_gen
             k0_electron = 2*k0_CO + 6*k0_C2H4
-            J_gen_corrected = J_gen + t_H * k0_electron * c03 * L
-            c03 = J_gen_corrected / torch.clamp(denominator, min=1e-20)
 
             # OH- and pH Calculation (linear balance)
             r_OH_gen = r_H2 + k0_electron * c03

--- a/carbondriver/gde_multi.py
+++ b/carbondriver/gde_multi.py
@@ -300,11 +300,6 @@ class System(torch.nn.Module):
         DCO2 = self.bruggeman(self.diffusion_coefficients['CO2'], eps)
         E_CO = self.electrode_reaction_potentials['E_0_CO']
         co2_equilibrium = self.co2_equilibrium
-        c_CO2_bulk = co2_equilibrium['CO2']
-        if self.system_phase == 'liquid':
-            co2_transfer_coeff = self.flow_channel_characteristics['K_L_CO2']
-        else:
-            co2_transfer_coeff = gdl_mass_transfer_coeff
             
         OH_neg = co2_equilibrium['OH']
         HCO3_neg = co2_equilibrium['HCO3']
@@ -320,158 +315,175 @@ class System(torch.nn.Module):
         k0_C2H4 = A/(6*F) * self.electrode_reaction_kinetics['i_0_C2H4'] * thetas['C2H4']/self.chemical_reaction_rates['c_ref'] * torch.exp(
             -overpotential_C2H4 * self.butler_volmer_factor*self.electrode_reaction_kinetics['alpha_C2H4'])
         k0 = k0_CO + k0_C2H4
-        eff_0 = 1/(M(k0)/torch.tanh(M(k0)) + k0*L/co2_transfer_coeff)
+        
+        # HER Rate (used in both branches)
+        r_H2 = A*self.electrode_reaction_kinetics['i_0_H2b'] * thetas['H2b']/F * torch.exp(-phi_ext*self.butler_volmer_factor*self.electrode_reaction_kinetics['alpha_H2b'])
+
         if self.system_phase == 'liquid':
-            c00 = c_CO2_bulk*eff_0
+            # ============================================================
+            # LIQUID/BPM CASE: Neumann BC (flux source at BPM interface)
+            # ============================================================
+            t_H = 0.9  # H+ transference number through BPM
+            co2_transfer_coeff = self.flow_channel_characteristics['K_L_CO2']
+            
+            M_val = M(k0)
+            eff_rxn = torch.tanh(M_val) / M_val
+            J_gen = t_H * r_H2 * L
+            denominator = k0 * L * eff_rxn + co2_transfer_coeff
+            c03 = J_gen / torch.clamp(denominator, min=1e-20)
+            
+            # One correction iteration for CO2R contribution to J_gen
+            k0_electron = 2*k0_CO + 6*k0_C2H4
+            J_gen_corrected = J_gen + t_H * k0_electron * c03 * L
+            c03 = J_gen_corrected / torch.clamp(denominator, min=1e-20)
+
+            # OH- and pH Calculation (linear balance)
+            r_OH_gen = r_H2 + k0_electron * c03
+            c12 = OH_neg + (
+                self.flow_channel_characteristics['K_L_OH'] * OH_neg + L * r_OH_gen
+            ) / (self.flow_channel_characteristics['K_L_OH'] + 2 * self.chemical_reaction_rates['k1f'] * L * eps * c03)
+
+            # Carbonate and HCO3 Balance (linear)
+            A_1_1 = (
+                2*self.flow_channel_characteristics['K_L_CO3']*CO3_2neg + 
+                self.flow_channel_characteristics['K_L_HCO3']*HCO3_neg + 
+                self.flow_channel_characteristics['K_L_OH']*OH_neg + 
+                L*r_H2 - self.flow_channel_characteristics['K_L_OH']*c12
+            ) / (2*self.flow_channel_characteristics['K_L_CO3'])
+            B_2_1 = (L * 2 * k0 * c03) / (2 * self.flow_channel_characteristics['K_L_CO3'])
+            c21 = torch.maximum(A_1_1 + B_2_1, torch.zeros_like(A_1_1))
+
         else:
+            # ============================================================
+            # GAS CASE: 3-step coupling with salting-out
+            # ============================================================
+            # Step 1: Initial guess (no equilibrium)
+            eff_0 = 1/(M(k0)/torch.tanh(M(k0)) + k0*L/gdl_mass_transfer_coeff)
             c00 = Hnr*self.p0*eff_0
 
-        # estimating OH- concentration
-        r_H2 = A*self.electrode_reaction_kinetics['i_0_H2b'] * thetas['H2b']/F * torch.exp(-phi_ext*self.butler_volmer_factor*self.electrode_reaction_kinetics['alpha_H2b']) # phi_ext is with respect to SHE
-        r_H2_CO2 = (2*k0_CO + 6*k0_C2H4)*c00
-        c10 = OH_neg+(
-            self.flow_channel_characteristics['K_L_OH']*OH_neg - 
-            1/(
-                1/(L*(r_H2+r_H2_CO2)) +
-                1/(self.flow_channel_characteristics['K_L_HCO3']*HCO3_neg)
+            # Step 2: First OH- estimate
+            r_H2_CO2 = (2*k0_CO + 6*k0_C2H4)*c00
+            c10 = OH_neg+(
+                self.flow_channel_characteristics['K_L_OH']*OH_neg - 
+                1/(
+                    1/(L*(r_H2+r_H2_CO2)) +
+                    1/(self.flow_channel_characteristics['K_L_HCO3']*HCO3_neg)
+                )
+                + L*(r_H2+r_H2_CO2)
+            ) / (
+                self.flow_channel_characteristics['K_L_OH'] + 2*eps*L*self.chemical_reaction_rates['k1f']*c00
             )
-            + L*(r_H2+r_H2_CO2)
-        ) / (
-            self.flow_channel_characteristics['K_L_OH'] + 2*eps*L*self.chemical_reaction_rates['k1f']*c00
-        )
 
-        # update CO2 concentration 
-        k1 = k0 + eps*self.chemical_reaction_rates['k1f']*c10
-        eff_1 = 1/(M(k1)/torch.tanh(M(k1)) + k1*L/co2_transfer_coeff)
-        if self.system_phase == 'liquid':
-            c01 = eff_1*c_CO2_bulk
-        else:
+            # update CO2 concentration 
+            k1 = k0 + eps*self.chemical_reaction_rates['k1f']*c10
+            eff_1 = 1/(M(k1)/torch.tanh(M(k1)) + k1*L/gdl_mass_transfer_coeff)
             c01 = eff_1*self.p0*Hnr
-        # update OH- concentration
-        r_H2_CO2 = (2*k0_CO + 6*k0_C2H4)*c01
-        c11 = OH_neg + (
-            self.flow_channel_characteristics['K_L_OH']*OH_neg - 1/(
-                1/(L*(r_H2+r_H2_CO2)) + 1/(self.flow_channel_characteristics['K_L_HCO3']*HCO3_neg)
-            ) + L*(r_H2+r_H2_CO2) 
-            ) / (
-            self.flow_channel_characteristics['K_L_OH']+2*self.chemical_reaction_rates['k1f']*L*eps*c01
-        )
-        # solve for CO3--
-        A_1 = (
-            2*self.flow_channel_characteristics['K_L_CO3']*CO3_2neg + self.flow_channel_characteristics['K_L_HCO3']*HCO3_neg + self.flow_channel_characteristics['K_L_OH']*OH_neg + L*r_H2 - self.flow_channel_characteristics['K_L_OH']*c11
-        ) / (2*self.flow_channel_characteristics['K_L_CO3'])
-        B_2 = L*2*k0*c01 / (2*self.flow_channel_characteristics['K_L_CO3']) * torch.exp(-c11*(self.salting_out_exponents['h_OH']+self.salting_out_exponents['h_K']))
-        C = self.salting_out_exponents['h_CO3']+2*self.salting_out_exponents['h_K']
-        c20 = A_1+torch.log(
-            1+(B_2*C * torch.exp(-A_1*C)) / (1+torch.log(torch.sqrt(1+B_2*C*torch.exp(-A_1*C))))
-            ) / C
-        # salting out corrected CO2 concentration
-        if self.system_phase == 'liquid':
-            c02 = eff_1*c_CO2_bulk
-        else:
-            c02 = eff_1*self.p0*Hnr_c(c11,c20)
-        r_H2_CO2 = (2*k0_CO + 6*k0_C2H4)*c02
-        # corrected OH- concentration
-        c12 = OH_neg + (
-            self.flow_channel_characteristics['K_L_OH']*OH_neg - 1/(
-                1/(L*(r_H2+r_H2_CO2)) + 1/(self.flow_channel_characteristics['K_L_HCO3']*HCO3_neg)
-            ) + L*(r_H2+r_H2_CO2)
-            ) / (
-            self.flow_channel_characteristics['K_L_OH']+2*self.chemical_reaction_rates['k1f']*L*eps*c02
-        )
-
-        k2 = k0 + eps*self.chemical_reaction_rates['k1f']*c12
-        eff_2 = 1/(
-            torch.sqrt(
-                k2*L**2/DCO2
-            ) / torch.tanh(torch.sqrt(
-                k2*L**2/DCO2
-            )) + k2*L/co2_transfer_coeff
-        )
-        A_1_1 = (
-            2*self.flow_channel_characteristics['K_L_CO3']*CO3_2neg + self.flow_channel_characteristics['K_L_HCO3']*HCO3_neg + self.flow_channel_characteristics['K_L_OH']*OH_neg + L*r_H2 - self.flow_channel_characteristics['K_L_OH']*c12
-        ) / (2*self.flow_channel_characteristics['K_L_CO3'])
-        # formula for this B2 is different than for the previous B2
-        if self.system_phase == 'liquid':
-            B_2_1 = L*2*k0*eff_2*c_CO2_bulk / (2*self.flow_channel_characteristics['K_L_CO3']) * torch.exp(-c12*(self.salting_out_exponents['h_OH']+self.salting_out_exponents['h_K']))
-        else:
-            B_2_1 = L*2*k0*eff_2*Hnr*self.p0 / (2*self.flow_channel_characteristics['K_L_CO3']) * torch.exp(-c12*(self.salting_out_exponents['h_OH']+self.salting_out_exponents['h_K']))
-        c21 = A_1_1+torch.log(
-            1+(
-                B_2_1*(self.salting_out_exponents['h_CO3']+2*self.salting_out_exponents['h_K']) * torch.exp(-A_1_1*(self.salting_out_exponents['h_CO3']+2*self.salting_out_exponents['h_K']))
+            
+            # update OH- concentration
+            r_H2_CO2 = (2*k0_CO + 6*k0_C2H4)*c01
+            c11 = OH_neg + (
+                self.flow_channel_characteristics['K_L_OH']*OH_neg - 1/(
+                    1/(L*(r_H2+r_H2_CO2)) + 1/(self.flow_channel_characteristics['K_L_HCO3']*HCO3_neg)
+                ) + L*(r_H2+r_H2_CO2) 
                 ) / (
-                    1+torch.log(torch.sqrt(1+B_2_1*(self.salting_out_exponents['h_CO3']+2*self.salting_out_exponents['h_K'])*torch.exp(-A_1_1*(self.salting_out_exponents['h_CO3']+2*self.salting_out_exponents['h_K']))))
-                    )
-            ) / (
-            self.salting_out_exponents['h_CO3']+2*self.salting_out_exponents['h_K']
-        )
-        c21 = torch.maximum(c21, torch.zeros_like(c21))
-        if self.system_phase == 'liquid':
-            c03 = c_CO2_bulk*eff_2
-        else:
+                self.flow_channel_characteristics['K_L_OH']+2*self.chemical_reaction_rates['k1f']*L*eps*c01
+            )
+            
+            # Step 3: Solve for CO3-- (log approximation)
+            A_1 = (
+                2*self.flow_channel_characteristics['K_L_CO3']*CO3_2neg + self.flow_channel_characteristics['K_L_HCO3']*HCO3_neg + self.flow_channel_characteristics['K_L_OH']*OH_neg + L*r_H2 - self.flow_channel_characteristics['K_L_OH']*c11
+            ) / (2*self.flow_channel_characteristics['K_L_CO3'])
+            B_2 = L*2*k0*c01 / (2*self.flow_channel_characteristics['K_L_CO3']) * torch.exp(-c11*(self.salting_out_exponents['h_OH']+self.salting_out_exponents['h_K']))
+            C = self.salting_out_exponents['h_CO3']+2*self.salting_out_exponents['h_K']
+            c20 = A_1+torch.log(
+                1+(B_2*C * torch.exp(-A_1*C)) / (1+torch.log(torch.sqrt(1+B_2*C*torch.exp(-A_1*C))))
+                ) / C
+            
+            # salting out corrected CO2 concentration
+            c02 = eff_1*self.p0*Hnr_c(c11,c20)
+            r_H2_CO2 = (2*k0_CO + 6*k0_C2H4)*c02
+            
+            # corrected OH- concentration
+            c12 = OH_neg + (
+                self.flow_channel_characteristics['K_L_OH']*OH_neg - 1/(
+                    1/(L*(r_H2+r_H2_CO2)) + 1/(self.flow_channel_characteristics['K_L_HCO3']*HCO3_neg)
+                ) + L*(r_H2+r_H2_CO2)
+                ) / (
+                self.flow_channel_characteristics['K_L_OH']+2*self.chemical_reaction_rates['k1f']*L*eps*c02
+            )
+
+            k2 = k0 + eps*self.chemical_reaction_rates['k1f']*c12
+            eff_2 = 1/(
+                torch.sqrt(k2*L**2/DCO2) / torch.tanh(torch.sqrt(k2*L**2/DCO2)) + k2*L/gdl_mass_transfer_coeff
+            )
+            
+            # Final CO3-- calculation
+            A_1_1 = (
+                2*self.flow_channel_characteristics['K_L_CO3']*CO3_2neg + self.flow_channel_characteristics['K_L_HCO3']*HCO3_neg + self.flow_channel_characteristics['K_L_OH']*OH_neg + L*r_H2 - self.flow_channel_characteristics['K_L_OH']*c12
+            ) / (2*self.flow_channel_characteristics['K_L_CO3'])
+            B_2_1 = L*2*k0*eff_2*Hnr*self.p0 / (2*self.flow_channel_characteristics['K_L_CO3']) * torch.exp(-c12*(self.salting_out_exponents['h_OH']+self.salting_out_exponents['h_K']))
+            c21 = A_1_1+torch.log(
+                1+(
+                    B_2_1*(self.salting_out_exponents['h_CO3']+2*self.salting_out_exponents['h_K']) * torch.exp(-A_1_1*(self.salting_out_exponents['h_CO3']+2*self.salting_out_exponents['h_K']))
+                    ) / (
+                        1+torch.log(torch.sqrt(1+B_2_1*(self.salting_out_exponents['h_CO3']+2*self.salting_out_exponents['h_K'])*torch.exp(-A_1_1*(self.salting_out_exponents['h_CO3']+2*self.salting_out_exponents['h_K']))))
+                        )
+                ) / (
+                self.salting_out_exponents['h_CO3']+2*self.salting_out_exponents['h_K']
+            )
+            c21 = torch.maximum(c21, torch.zeros_like(c21))
             c03 = self.p0*Hnr_c(c12, c21)*eff_2
+
+        # ============================================================
+        # FINAL OUTPUT COMPILATION (Common to both)
+        # ============================================================
         potential_vs_rhe = phi_ext - R*T/F*torch.log(c12/OH_neg)
         co_current_density = L*c03*k0_CO*2*F/10 # mA/cm^2
         c2h4_current_density = L*c03*k0_C2H4*6*F/10 # mA/cm^2
-        co2 = c03
-        co3 = c21
-        pH = torch.log10(c12/1000/self.initial_carbonate_equilibria['Kw'])
         current_density = co_current_density + c2h4_current_density + (F*L*r_H2)/10 # mA/cm^2
+        
+        if self.system_phase == 'liquid':
+            pKw = -torch.log10(torch.as_tensor(self.initial_carbonate_equilibria['Kw'], dtype=c12.dtype, device=c12.device))
+            pH = pKw + torch.log10(torch.clamp(c12 / 1000, min=1e-14))
+        else:
+            pH = torch.log10(c12/1000/self.initial_carbonate_equilibria['Kw'])
+
         fe_co = co_current_density / current_density
         fe_c2h4 = c2h4_current_density / current_density
-        parasitic = c03*c12*eps*L*self.chemical_reaction_rates['k1f']
-        electrode = L*k0*c03
+        
         if self.system_phase == 'liquid':
+            parasitic = c03*c12*eps*L*self.chemical_reaction_rates['k1f']
+            electrode = L*k0*c03
             gdl_flux = torch.zeros_like(c03)
             hco3 = torch.minimum(
-                HCO3_neg+c_CO2_bulk,
-                co3*10**(3-pH)/self.initial_carbonate_equilibria['K1']
+                torch.as_tensor(HCO3_neg, dtype=c21.dtype),
+                c21*10**(3-pH)/self.initial_carbonate_equilibria['K1']
             )
             solubility = torch.ones_like(c03)
         else:
+            parasitic = c03*c12*eps*L*self.chemical_reaction_rates['k1f']
+            electrode = L*k0*c03
             gdl_flux = gdl_mass_transfer_coeff*(
-                Hnr_c(c12,c21)*self.p0 - c03*torch.sqrt(
-                    k2*L**2/DCO2
-                ) / torch.tanh(
-                    torch.sqrt(k2*L**2/DCO2)
-                )
+                Hnr_c(c12,c21)*self.p0 - c03*torch.sqrt(k2*L**2/DCO2) / torch.tanh(torch.sqrt(k2*L**2/DCO2))
             )
             hco3 = torch.minimum(
                 HCO3_neg+Hnr_c(c12,c21)*self.p0,
-                co3*10**(3-pH)/self.initial_carbonate_equilibria['K1']
+                c21*10**(3-pH)/self.initial_carbonate_equilibria['K1']
             )
             solubility = Hnr_c(c12,c21)/Hnr
-        # deleted voltage and energy efficiencies for now, just to avoid possible bugs
+
         return {
             'phi_ext': phi_ext,
             'k0': k0,
-            'eff_0': eff_0,
-            'c00': c00,
             'r_H2': r_H2,
-            'r_H2_CO2': r_H2_CO2, # H2 consumption rate due to CO2 reduction / OH- generation rate
-            'c10': c10,
-            'k1': k1,
-            'eff_1': eff_1,
-            'c01': c01,
-            'c11': c11,
-            'A_1': A_1,
-            'B_2': B_2,
-            'c20': c20,
-            'c02': c02,
-            'c12': c12,
-            'k2': k2,
-            'eff_2': eff_2,
-            'c03': c03,
-            'c21': c21,
-            'A_1_1': A_1_1,
-            'B_2_1': B_2_1,
             'potential_vs_rhe': potential_vs_rhe,
             'h2_current_density': F*L*r_H2/10,
             'co_current_density': co_current_density,
             'c2h4_current_density': c2h4_current_density,
             'current_density': current_density,
-            'co2': co2,
-            'co3': co3,
+            'co2': c03,
+            'co3': c21,
+            'oh': c12,
             'pH': pH,
             'fe_co': fe_co,
             'fe_c2h4': fe_c2h4,

--- a/carbondriver/test_gde_multi.py
+++ b/carbondriver/test_gde_multi.py
@@ -1,8 +1,9 @@
 from carbondriver import gde_multi
+import pytest
 import torch
 
 
-def _make_system(system_phase='solid'):
+def _make_system(system_phase='solid', method='CO2 eql'):
     erc = gde_multi.electrode_reaction_kinetics | {}
     erc['i_0_CO'] = torch.nn.parameter.Parameter(torch.tensor(erc['i_0_CO']))
     erc['i_0_C2H4'] = torch.nn.parameter.Parameter(torch.tensor(erc['i_0_C2H4']))
@@ -16,6 +17,7 @@ def _make_system(system_phase='solid'):
         electrode_reaction_kinetics=erc,
         electrode_reaction_potentials=gde_multi.electrode_reaction_potentials,
         chemical_reaction_rates=gde_multi.chemical_reaction_rates,
+        method=method,
         system_phase=system_phase,
     )
 
@@ -33,18 +35,23 @@ def _base_inputs():
     return eps, r, L, thetas, gdl_mass_transfer_coefficient
 
 
-def test_solid_mode_defaults_to_co2_equilibrium_method():
-    ph_model = _make_system(system_phase='solid')
-    assert ph_model.method == 'CO2 eql'
+@pytest.mark.parametrize(
+    'method',
+    ['CO2 eql', 'DIC'],
+)
+def test_solid_mode_keeps_requested_method(method):
+    ph_model = _make_system(system_phase='solid', method=method)
+    assert ph_model.method == method
 
 
-def test_liquid_mode_forces_dic_method():
-    ph_model = _make_system(system_phase='liquid')
+def test_liquid_mode_forces_dic_method_even_when_co2_equilibrium_requested():
+    ph_model = _make_system(system_phase='liquid', method='CO2 eql')
     assert ph_model.method == 'DIC'
 
 
-def test_solve_current_runs_in_solid_mode_with_gdl_flux_key():
-    ph_model = _make_system(system_phase='solid')
+@pytest.mark.parametrize('system_phase', ['solid', 'liquid'])
+def test_solve_current_runs_for_each_physics_mode(system_phase):
+    ph_model = _make_system(system_phase=system_phase)
     eps, r, L, thetas, gdl_mass_transfer_coefficient = _base_inputs()
 
     solution = ph_model.solve_current(
@@ -59,24 +66,16 @@ def test_solve_current_runs_in_solid_mode_with_gdl_flux_key():
     )
 
     assert 'gdl_flux' in solution
-    assert torch.isfinite(solution['current_density']).all()
+    assert 'current_density' in solution
+    assert 'pH' in solution
+    assert torch.isfinite(solution['current_density']).all().item()
+    assert torch.isfinite(solution['pH']).all().item()
+
+    if system_phase == 'liquid':
+        assert torch.allclose(solution['gdl_flux'], torch.zeros_like(solution['gdl_flux']))
+    else:
+        assert torch.isfinite(solution['gdl_flux']).all().item()
 
 
-def test_solve_current_runs_in_liquid_mode_with_zero_gdl_flux():
-    ph_model = _make_system(system_phase='liquid')
-    eps, r, L, thetas, gdl_mass_transfer_coefficient = _base_inputs()
-
-    solution = ph_model.solve_current(
-        i_target=233,
-        eps=eps,
-        r=r,
-        L=L,
-        thetas=thetas,
-        gdl_mass_transfer_coeff=gdl_mass_transfer_coefficient,
-        grid_size=1000,
-        voltage_bounds=(-1.25, 0),
-    )
-
-    assert 'gdl_flux' in solution # Make sure we still have the gdl_flux key in liquid mode
-    assert torch.allclose(solution['gdl_flux'], torch.zeros_like(solution['gdl_flux'])) # Make sure we actually have zero gdl flux in liquid mode
-    assert torch.isfinite(solution['current_density']).all() # Make sure we still get a valid current density solution in liquid mode
+if __name__ == '__main__':
+    raise SystemExit(pytest.main([__file__]))

--- a/carbondriver/test_gde_multi.py
+++ b/carbondriver/test_gde_multi.py
@@ -2,41 +2,81 @@ from carbondriver import gde_multi
 import torch
 
 
-erc = gde_multi.electrode_reaction_kinetics | {}
-erc['i_0_CO'] = torch.nn.parameter.Parameter(torch.tensor(erc['i_0_CO']))
-erc['i_0_C2H4'] = torch.nn.parameter.Parameter(torch.tensor(erc['i_0_C2H4']))
-erc['i_0_H2b'] = torch.nn.parameter.Parameter(torch.tensor(erc['i_0_H2b']))
-erc['alpha_CO'] = torch.nn.parameter.Parameter(torch.tensor(erc['alpha_CO']))
-erc['alpha_C2H4'] = torch.nn.parameter.Parameter(torch.tensor(erc['alpha_C2H4']))
-erc['alpha_H2b'] = torch.nn.parameter.Parameter(torch.tensor(erc['alpha_H2b']))
-ph_model = gde_multi.System(
-    diffusion_coefficients=gde_multi.diffusion_coefficients, 
-    salting_out_exponents=gde_multi.salting_out_exponents, 
-    electrode_reaction_kinetics=erc,
-    electrode_reaction_potentials=gde_multi.electrode_reaction_potentials,
-    chemical_reaction_rates=gde_multi.chemical_reaction_rates,
-        )  
+def _make_system(system_phase='solid'):
+    erc = gde_multi.electrode_reaction_kinetics | {}
+    erc['i_0_CO'] = torch.nn.parameter.Parameter(torch.tensor(erc['i_0_CO']))
+    erc['i_0_C2H4'] = torch.nn.parameter.Parameter(torch.tensor(erc['i_0_C2H4']))
+    erc['i_0_H2b'] = torch.nn.parameter.Parameter(torch.tensor(erc['i_0_H2b']))
+    erc['alpha_CO'] = torch.nn.parameter.Parameter(torch.tensor(erc['alpha_CO']))
+    erc['alpha_C2H4'] = torch.nn.parameter.Parameter(torch.tensor(erc['alpha_C2H4']))
+    erc['alpha_H2b'] = torch.nn.parameter.Parameter(torch.tensor(erc['alpha_H2b']))
+    return gde_multi.System(
+        diffusion_coefficients=gde_multi.diffusion_coefficients,
+        salting_out_exponents=gde_multi.salting_out_exponents,
+        electrode_reaction_kinetics=erc,
+        electrode_reaction_potentials=gde_multi.electrode_reaction_potentials,
+        chemical_reaction_rates=gde_multi.chemical_reaction_rates,
+        system_phase=system_phase,
+    )
 
-eps = torch.tensor(0.5)
-r = torch.tensor(3e-8)
-L = torch.tensor(1e-5)
-thetas = {
-    'CO': torch.tensor(0.3),
-    'C2H4': torch.tensor(0.3),
-    'H2b': torch.tensor(0.4)
-}
-gdl_mass_transfer_coefficient = torch.tensor(0.015)
 
-solution = ph_model.solve_current(
-    i_target=233,
-    eps=eps,
-    r=r,
-    L=L,
-    thetas=thetas,
-    gdl_mass_transfer_coeff=gdl_mass_transfer_coefficient,
-    grid_size=1000,
-    voltage_bounds=(-1.25,0)
-)
+def _base_inputs():
+    eps = torch.tensor(0.5)
+    r = torch.tensor(3e-8)
+    L = torch.tensor(1e-5)
+    thetas = {
+        'CO': torch.tensor(0.3),
+        'C2H4': torch.tensor(0.3),
+        'H2b': torch.tensor(0.4),
+    }
+    gdl_mass_transfer_coefficient = torch.tensor(0.015)
+    return eps, r, L, thetas, gdl_mass_transfer_coefficient
 
-print(solution)
-print("Voltage (V vs SHE): ", solution['voltage'])
+
+def test_solid_mode_defaults_to_co2_equilibrium_method():
+    ph_model = _make_system(system_phase='solid')
+    assert ph_model.method == 'CO2 eql'
+
+
+def test_liquid_mode_forces_dic_method():
+    ph_model = _make_system(system_phase='liquid')
+    assert ph_model.method == 'DIC'
+
+
+def test_solve_current_runs_in_solid_mode_with_gdl_flux_key():
+    ph_model = _make_system(system_phase='solid')
+    eps, r, L, thetas, gdl_mass_transfer_coefficient = _base_inputs()
+
+    solution = ph_model.solve_current(
+        i_target=233,
+        eps=eps,
+        r=r,
+        L=L,
+        thetas=thetas,
+        gdl_mass_transfer_coeff=gdl_mass_transfer_coefficient,
+        grid_size=1000,
+        voltage_bounds=(-1.25, 0),
+    )
+
+    assert 'gdl_flux' in solution
+    assert torch.isfinite(solution['current_density']).all()
+
+
+def test_solve_current_runs_in_liquid_mode_with_zero_gdl_flux():
+    ph_model = _make_system(system_phase='liquid')
+    eps, r, L, thetas, gdl_mass_transfer_coefficient = _base_inputs()
+
+    solution = ph_model.solve_current(
+        i_target=233,
+        eps=eps,
+        r=r,
+        L=L,
+        thetas=thetas,
+        gdl_mass_transfer_coeff=gdl_mass_transfer_coefficient,
+        grid_size=1000,
+        voltage_bounds=(-1.25, 0),
+    )
+
+    assert 'gdl_flux' in solution # Make sure we still have the gdl_flux key in liquid mode
+    assert torch.allclose(solution['gdl_flux'], torch.zeros_like(solution['gdl_flux'])) # Make sure we actually have zero gdl flux in liquid mode
+    assert torch.isfinite(solution['current_density']).all() # Make sure we still get a valid current density solution in liquid mode


### PR DESCRIPTION
The previous liquid branch incorrectly used the gas-model logic (Dirichlet CO₂ source from DIC equilibrium) as a stand-in for the BPM bicarbonate system (What I initially proposed with those 3 section changes (BC, salting outing, etc). This was physically wrong — in the BPM system CO₂ is generated in-situ by H⁺ flux reacting with HCO₃⁻, not fed from an external gas source.
What changed:
The liquid branch now **solves the same 1D steady-state diffusion-reaction PDE as the gas model but with flipped boundary conditions:**

x=0 (BPM/CL interface): Neumann BC — H⁺ flux from BPM generates CO₂ proportional to total current via transference number t_H = 0.9
x=L (CL/flow channel interface): Robin BC — mass transfer to bulk channel via K_L_CO2

Rather than solving the PDE spatially, both BCs are encoded exactly into a volume-averaged effectiveness factor eta_c derived analytically from the cosh/sinh solution. This is the same 0D collapse used in the gas model, just with the source and sink boundaries swapped. The Sherwood number Sh = k_MT * L / D appears naturally in eta_c and correctly captures both limits: reaction-limited (large M) and diffusion-limited (small M).
The CO2RR feedback — where each CO₂ reduced also delivers an H⁺ that generates another CO₂ — is handled exactly by moving the t_H * k0_electron * L term to the denominator, giving a closed-form self-consistent solution with no iteration.
M_val is clamped to 1e-6 to avoid division-by-zero in eta_c at near-zero reaction rates. The denominator of the final c03 expression is clamped to 1e-20 to guard against negative values at extreme voltages where CO2R generation exceeds consumption. We should ask if OH- generation is significant from the CO2RR and HER in the Cathode side, could be simplified but if it does not change this implementation should still hold. 